### PR TITLE
Update GELF format

### DIFF
--- a/journal2gelf
+++ b/journal2gelf
@@ -99,7 +99,7 @@ class JournalToGelf:
                 elif key == 'PRIORITY':
                     msg['level'] = int(value)
                 elif key == 'SYSLOG_FACILITY':
-                    msg['facility'] = self.facility_names.get(int(value), 'unknown')
+                    msg['_facility'] = self.facility_names.get(int(value), 'unknown')
                 elif key == '_HOSTNAME':
                     msg['host'] = value
                 elif key == 'MESSAGE':


### PR DESCRIPTION
Apparently, 'facility' is no longer an expected top level keyword. This was causing incoming messages to be ignored by the server. Changing facility to be an 'additional field' by prepending an underscore fixes this issue.
