### PR TITLE
Use readline on the input fd instead of iterating

### DIFF
--- a/journal2gelf
+++ b/journal2gelf
@@ -118,7 +118,7 @@ class JournalToGelf:
             self.buf.clear()
 
     def run(self):
-        for line in self.fp:
+        for line in iter(self.fp.readline, ''):
             line = line.strip()
 
             # systemd > 190 switched to a single-line JSON format for each


### PR DESCRIPTION
In Python 2.x, using 'for line in self.fd' causes messages to be delayed and arrive in bursts due to internal read-ahead buffering, see http://bugs.python.org/issue3907 and http://stackoverflow.com/questions/2804543/read-subprocess-stdout-line-by-line
Using readline() explicitly avoids this problem as it doesn't read ahead.